### PR TITLE
fixed modify button, added num_hosts, changed python path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This script auto click web pages to renew the hosts,
 using Python/Selenium with Chrome headless mode.
 
 - Platform: Debian/Ubuntu Linux, no GUI needed (tested on Debian 9.x); python 2.x/3.x
-- Ver: 0.3
+- Ver: 0.4
 - Ref: [Technical explanation for the code (Chinese)](http://www.jianshu.com/p/3c8196175147)
-- Updated: 5/19/2018
+- Updated: 12/01/2018
 - Created: 11/4/2017
 - Author: loblab
 
@@ -15,7 +15,7 @@ using Python/Selenium with Chrome headless mode.
 
 ## Usage
 
-1. Set your noip.com account info in noip-renew.sh,
+1. Set your noip.com account info and number of hosts in noip-renew.sh,
 2. Run setup.sh,
 3. Run noip-renew.sh, check result.png (if succeeded) or error.png (if failed)
 
@@ -30,6 +30,7 @@ There is no chromedriver on Raspberry Pi by default. You may need to install it 
 
 ## History
 
+- 0.4 (12/01/2018): added num_hosts parameter, fixed modify button label
 - 0.3 (5/19/2018): Support Docker, ignore timeout, support proxy, tested on python3.
 - 0.2 (11/12/2017): Deploy the script as normal user only. root user with 'no-sandbox' option is not safe for Chrome.
 - 0.1 (11/5/2017): Supported Debian with Chrome headless.

--- a/noip-renew.py
+++ b/noip-renew.py
@@ -23,7 +23,7 @@ class Robot:
 
     LOGIN_URL = "https://www.noip.com/login"
     HOST_URL = "https://my.noip.com/#!/dynamic-dns"
-    NUM_HOSTS = 3
+    NUM_HOSTS = num_hosts
 
     def __init__(self, debug=0):
         self.debug = debug
@@ -79,7 +79,7 @@ class Robot:
         while retry > 0:
             time.sleep(1)
             buttons_todo = self.browser.find_elements_by_xpath(Robot.xpath_of_button('btn-confirm'))
-            buttons_done = self.browser.find_elements_by_xpath(Robot.xpath_of_button('btn-manage'))
+            buttons_done = self.browser.find_elements_by_xpath(Robot.xpath_of_button('btn-configure'))
             count = len(buttons_todo)
             if count + len(buttons_done) == Robot.NUM_HOSTS:
                 invalid = False
@@ -117,15 +117,16 @@ class Robot:
 def main(argv=None):
     if argv is None:
         argv = sys.argv
-    if len(argv) < 3:
-        print("Usage: %s <username> <password> [<debug-level>]" % argv[0])
+    if len(argv) < 4:
+        print("Usage: %s <username> <password> <num-hosts> [<debug-level>]" % argv[0])
         return 1
 
     username = argv[1]
     password = argv[2]
+    num_hosts = argv[3]
     debug = 1
-    if len(argv) > 3:
-        debug = int(argv[3])
+    if len(argv) > 4:
+        debug = int(argv[4])
 
     robot = Robot(debug)
     return robot.run(username, password)

--- a/noip-renew.py
+++ b/noip-renew.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 # Copyright 2017 loblab
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ class Robot:
 
     LOGIN_URL = "https://www.noip.com/login"
     HOST_URL = "https://my.noip.com/#!/dynamic-dns"
-    NUM_HOSTS = num_hosts
 
     def __init__(self, debug=0):
         self.debug = debug
@@ -67,7 +66,7 @@ class Robot:
     def xpath_of_button(cls_name):
         return "//button[contains(@class, '%s')]" % cls_name 
 
-    def update_hosts(self):
+    def update_hosts(self, num_hosts):
         self.log_msg("Open %s..." % Robot.HOST_URL)
         try:
             self.browser.get(Robot.HOST_URL)
@@ -81,7 +80,7 @@ class Robot:
             buttons_todo = self.browser.find_elements_by_xpath(Robot.xpath_of_button('btn-confirm'))
             buttons_done = self.browser.find_elements_by_xpath(Robot.xpath_of_button('btn-configure'))
             count = len(buttons_todo)
-            if count + len(buttons_done) == Robot.NUM_HOSTS:
+            if count + len(buttons_done) == num_hosts:
                 invalid = False
                 break
             self.log_msg("Cannot find the buttons", 2)
@@ -100,11 +99,11 @@ class Robot:
         self.log_msg("Confirmed hosts: %d" % count, 2)
         return True
 
-    def run(self, username, password):
+    def run(self, username, password, num_hosts):
         rc = 0
         try:
             self.login(username, password)
-            if not self.update_hosts():
+            if not self.update_hosts(num_hosts):
                 rc = 3
         except Exception as e:
             self.log_msg(str(e), 2)
@@ -123,13 +122,13 @@ def main(argv=None):
 
     username = argv[1]
     password = argv[2]
-    num_hosts = argv[3]
+    num_hosts = int(argv[3])
     debug = 1
     if len(argv) > 4:
         debug = int(argv[4])
 
     robot = Robot(debug)
-    return robot.run(username, password)
+    return robot.run(username, password, num_hosts)
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/noip-renew.sh
+++ b/noip-renew.sh
@@ -2,13 +2,14 @@
 
 USERNAME="change-the-username"
 PASSWORD="change-the-password"
+NUM_HOSTS="3" # make sure to change this to the number of configured dynamic hosts on your no-ip account
 
 LOGDIR=$1
 
 if [ -z "$LOGDIR" ]; then
-    ./noip-renew.py "$USERNAME" "$PASSWORD" 2
+    ./noip-renew.py "$USERNAME" "$PASSWORD" "$NUM_HOSTS" 2
 else
     cd $LOGDIR
-    noip-renew.py "$USERNAME" "$PASSWORD" 0 >> log
+    noip-renew.py "$USERNAME" "$PASSWORD" "$NUM_HOSTS" 0 >> log
 fi
 


### PR DESCRIPTION
- "modify" button now has a "btn-configure" label instead of "btn-manage" fixes #2 

- added NUM_HOSTS as parameter instead of hardcoded to "3" for people using less than 3 dynamic hosts on the same account

- changed python invocation from "/usr/bin/python3" to "/usr/bin/env python" which is the most common way to call the available python on a system