### PR TITLE
Catches offer to upgrade page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Script to auto renew/confirm noip.com free hosts
 
 [noip.com](https://www.noip.com/) free hosts expire every month.
-This script auto click web pages to renew the hosts,
+This script auto clicks web pages to renew the hosts,
 using Python/Selenium with Chrome headless mode.
 
-- Platform: Debian/Ubuntu/Raspbian Linux, no GUI needed (tested on Debian 9.x/10.x); python 2.x/3.x
-- Ver: 0.9
+- Platform: Debian/Ubuntu/Raspbian Linux, no GUI needed (tested on Debian 9.x/10.x); python 3.6+
+- Ver: 0.10
 - Ref: [Technical explanation for the code (Chinese)](http://www.jianshu.com/p/3c8196175147)
-- Updated: 04/13/2020
+- Updated: 04/16/2020
 - Created: 11/04/2017
 - Author: loblab
-- Contributor: IDemixI
+- Contributor: [IDemixI](https://www.github.com/IDemixI)
 
 ![noip.com hosts](https://raw.githubusercontent.com/loblab/noip-renew/master/screenshot.png)
 
@@ -36,12 +36,13 @@ You can also check [DNS-O-Matic](https://dnsomatic.com/) to update multiple noip
 
 ## History
 
-- 0.9 (04/13/2020): Complete refactor of code, more stability & automatic crontab scheduling.
-- 0.8 (03/23/2020): Added menu to repair/install/remove script along with ability to update noip.com details.
-- 0.7 (03/21/2020): Code tidyup and improved efficiency (Removed number of hosts and automatically get this)
-- 0.6 (03/15/2020): Improved support for Raspberry Pi (Raspbian Buster) & Changes to setup script.
-- 0.5 (01/05/2020): Support raspberry pi, try different "chromedriver" packages in setup script.
-- 0.4 (01/14/2019): Add num_hosts argument, change for button renaming; support user agent.
-- 0.3 (05/19/2018): Support Docker, ignore timeout, support proxy, tested on python3.
-- 0.2 (11/12/2017): Deploy the script as normal user only. root user with 'no-sandbox' option is not safe for Chrome.
-- 0.1 (11/05/2017): Support Debian with Chrome headless.
+- 0.10 (04/16/2020): Now catches "Would you like to upgrade?" page and stops the script accordingly. Manual intervention still required.
+- 0.9  (04/13/2020): Complete refactor of code, more stability & automatic crontab scheduling.
+- 0.8  (03/23/2020): Added menu to repair/install/remove script along with ability to update noip.com details.
+- 0.7  (03/21/2020): Code tidyup and improved efficiency (Removed number of hosts and automatically get this)
+- 0.6  (03/15/2020): Improved support for Raspberry Pi (Raspbian Buster) & Changes to setup script.
+- 0.5  (01/05/2020): Support raspberry pi, try different "chromedriver" packages in setup script.
+- 0.4  (01/14/2019): Add num_hosts argument, change for button renaming; support user agent.
+- 0.3  (05/19/2018): Support Docker, ignore timeout, support proxy, tested on python3.
+- 0.2  (11/12/2017): Deploy the script as normal user only. root user with 'no-sandbox' option is not safe for Chrome.
+- 0.1  (11/05/2017): Support Debian with Chrome headless.

--- a/noip-renew.py
+++ b/noip-renew.py
@@ -99,7 +99,7 @@ class Robot:
                 self.update_host(host_button, host_name)
                 count += 1
             iteration += 1
-            self.browser.save_screenshot("results.png")
+        self.browser.save_screenshot("results.png")
         self.logger.log(f"Confirmed hosts: {count}", 2)
         nr = min(next_renewal) - 6
         today = date.today() + timedelta(days=nr)
@@ -120,6 +120,8 @@ class Robot:
         self.logger.log(f"Updating {host_name}")
         host_button.click()
         time.sleep(3)
+        if self.browser.find_elements_by_xpath("//h2[@class='big']")[0].text == "Upgrade Now":
+            raise Exception("Manual intervention required. Upgrade dialog triggered.")
         self.browser.save_screenshot(f"{host_name}_success.png")
 
     @staticmethod


### PR DESCRIPTION
Unfortunately, noip.com randomly gives you a "Before confirming your hostname" page and prompts you to upgrade every so often. This small change catches it and stops the script from falling over. Manual intervention is still required when this does occur. This should mean, you can close #14 as it's not technically an Issue/bug, just a "feature" of noip.com.