### PR TITLE
Changed crontab to work on Arch Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+debug1.png
+debug2.png
+results.png

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This script auto clicks web pages to renew the hosts,
 using Python/Selenium with Chrome headless mode.
 
-- Platform: Debian/Ubuntu/Raspbian Linux, no GUI needed (tested on Debian 9.x/10.x); python 3.6+
+- Platform: Debian/Ubuntu/Raspbian/Arch Linux, no GUI needed (tested on Debian 9.x/10.x/Arch Linux); python 3.6+
 - Ver: 1.1
 - Ref: [Technical explanation for the code (Chinese)](http://www.jianshu.com/p/3c8196175147)
 - Updated: 05/18/2020
@@ -18,7 +18,7 @@ using Python/Selenium with Chrome headless mode.
 
 1. Clone this repository to the device you will be running it from. (`git clone https://github.com/loblab/noip-renew.git`)
 2. Run setup.sh and set your noip.com account information,
-3. Run noip-renew.sh, check results.png (if succeeded) or error.png (if failed)
+3. Run noip-renew-USERNAME command.
 
 For docker users, check Dockerfile, docker-compose.yml, crontab-docker-host.
 

--- a/noip-renew-skd.sh
+++ b/noip-renew-skd.sh
@@ -5,9 +5,9 @@ SUDO=sudo
 LOGDIR=/var/log/noip-renew/$USER
 INSTDIR=/usr/local/bin
 INSTEXE=$INSTDIR/noip-renew-$USER
-CRONJOB="30 0    * * *   $USER    $INSTEXE $LOGDIR"
-NEWCJOB="30 0    $1 $2 *   $USER    $INSTEXE $LOGDIR"
-
+CRONJOB="30 0 * * *   $USER    $INSTEXE $LOGDIR"
+NEWCJOB="30 0 $1 $2 *   $USER    $INSTEXE $LOGDIR"
+$SUDO crontab -u $USER -l | grep -v '/noip-renew*'  | $SUDO crontab -u $USER -
 if [ $3 = "True" ]; then
     ($SUDO crontab -u $USER -l; echo "$NEWCRONJOB") | $SUDO crontab -u $USER -
 else

--- a/noip-renew-skd.sh
+++ b/noip-renew-skd.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 USER=
 SUDO=sudo
 LOGDIR=/var/log/noip-renew/$USER

--- a/noip-renew-skd.sh
+++ b/noip-renew-skd.sh
@@ -8,7 +8,7 @@ INSTEXE=$INSTDIR/noip-renew-$USER
 CRONJOB="30 0 * * *   $USER    $INSTEXE $LOGDIR"
 NEWCJOB="30 0 $1 $2 *   $USER    $INSTEXE $LOGDIR"
 $SUDO crontab -u $USER -l | grep -v '/noip-renew*'  | $SUDO crontab -u $USER -
-if [ $3 = "True" ]; then
+if [[ $3 = "True" ]]; then
     ($SUDO crontab -u $USER -l; echo "$NEWCJOB") | $SUDO crontab -u $USER -
 else
     ($SUDO crontab -u $USER -l; echo "$CRONJOB") | $SUDO crontab -u $USER -

--- a/noip-renew-skd.sh
+++ b/noip-renew-skd.sh
@@ -8,12 +8,10 @@ INSTEXE=$INSTDIR/noip-renew-$USER
 CRONJOB="30 0    * * *   $USER    $INSTEXE $LOGDIR"
 NEWCJOB="30 0    $1 $2 *   $USER    $INSTEXE $LOGDIR"
 
-$SUDO sed -i '/noip-renew/d' /etc/crontab
-
 if [ $3 = "True" ]; then
-    echo "$NEWCJOB" | $SUDO tee -a /etc/crontab
+    ($SUDO crontab -u $USER -l; echo "$NEWCRONJOB") | $SUDO crontab -u $USER -
 else
-    echo "$CRONJOB" | $SUDO tee -a /etc/crontab
+    ($SUDO crontab -u $USER -l; echo "$CRONJOB") | $SUDO crontab -u $USER -
 fi
 
 exit 0

--- a/noip-renew-skd.sh
+++ b/noip-renew-skd.sh
@@ -9,7 +9,7 @@ CRONJOB="30 0 * * *   $USER    $INSTEXE $LOGDIR"
 NEWCJOB="30 0 $1 $2 *   $USER    $INSTEXE $LOGDIR"
 $SUDO crontab -u $USER -l | grep -v '/noip-renew*'  | $SUDO crontab -u $USER -
 if [ $3 = "True" ]; then
-    ($SUDO crontab -u $USER -l; echo "$NEWCRONJOB") | $SUDO crontab -u $USER -
+    ($SUDO crontab -u $USER -l; echo "$NEWCJOB") | $SUDO crontab -u $USER -
 else
     ($SUDO crontab -u $USER -l; echo "$CRONJOB") | $SUDO crontab -u $USER -
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -24,29 +24,36 @@ function config() {
 }
 
 function install() {
-    echo "Installing necessary packages..."
-    read -p 'Perform apt-get update? (y/n): ' update
-    if [ "${update^^}" = "Y" ]
-    then
-      $SUDO apt-get update
+    OS=$(hostnamectl | grep -i "operating system")
+    if [[ $OS =~ "Arch Linux" ]]; then
+        $SUDO pacman -Qi python > /dev/null ||  (echo "Updating Python..." && $SUDO pacman -S python)
+        $SUDO pacman -Qi python-pip > /dev/null ||  $SUDO pacman -S python-pip
+        $SUDO pacman -Qi chromium > /dev/null || $SUDO pacman -S chromium
+    else
+        echo "Installing necessary packages..."
+        read -p 'Perform apt-get update? (y/n): ' update
+        if [ "${update^^}" = "Y" ]
+        then
+            $SUDO apt-get update
+        fi
+
+        $SUDO apt -y install chromium-chromedriver || \
+        $SUDO apt -y install chromium-driver || \
+        $SUDO apt -y install chromedriver
+
+        PYV=`python3 -c "import sys;t='{v[0]}{v[1]}'.format(v=list(sys.version_info[:2]));sys.stdout.write(t)";`
+        if [[ "$PYV" -lt "36" ]] || ! hash python3;
+        then
+            echo "This script requires Python version 3.6 or higher. Attempting to install..."
+            $SUDO apt-get -y install python3
+        fi
+
+        # Debian9 package 'python-selenium' does not work with chromedriver,
+        # Install from pip, which is newer
+        $SUDO apt -y install chromium-browser # Update Chromium Browser or script won't work.
+        $SUDO apt -y install $PYTHON-pip
+
     fi
-
-    $SUDO apt -y install chromium-chromedriver || \
-      $SUDO apt -y install chromium-driver || \
-      $SUDO apt -y install chromedriver
-
-
-    PYV=`python3 -c "import sys;t='{v[0]}{v[1]}'.format(v=list(sys.version_info[:2]));sys.stdout.write(t)";`
-    if [[ "$PYV" -lt "36" ]] || ! hash python3;
-    then
-      echo "This script requires Python version 3.6 or higher. Attempting to install..."
-      $SUDO apt-get -y install python3
-    fi
-
-    # Debian9 package 'python-selenium' does not work with chromedriver,
-    # Install from pip, which is newer
-    $SUDO apt -y install chromium-browser # Update Chromium Browser or script won't work.
-    $SUDO apt -y install $PYTHON-pip
     $SUDO $PYTHON -m pip install selenium
 }
 
@@ -67,8 +74,7 @@ function deploy() {
     $SUDO chown $USER $INSTDIR/noip-renew-skd.sh
     $SUDO chmod 700 $INSTEXE
     noip
-    $SUDO sed -i '/noip-renew/d' /etc/crontab
-    echo "$CRONJOB" | $SUDO tee -a /etc/crontab
+    ($SUDO crontab -u $USER -l; echo "$CRONJOB") | $SUDO crontab -u $USER -
     $SUDO sed -i 's/USER=/USER='$USER'/1' $INSTDIR/noip-renew-skd.sh
     echo "Installation Complete."
     echo "To change noip.com account details, please run setup.sh again."


### PR DESCRIPTION
Changed script to use `crontab` command so it can work on distros that use the command to manage cron jobs. Everything seems to work on Arch and Raspbian but may need further testing for stability.