### PR TITLE
/usr/local/bin/noip-renew-pi: No such file or directory

### DIFF
--- a/noip-renew-skd.sh
+++ b/noip-renew-skd.sh
@@ -3,7 +3,7 @@ USER=
 SUDO=sudo
 LOGDIR=/var/log/noip-renew/$USER
 INSTDIR=/usr/local/bin
-INSTEXE=$INSTDIR/noip-renew-$USER
+INSTEXE=$INSTDIR/noip-renew-$USER.sh
 CRONJOB="30 0 * * *   $USER    $INSTEXE $LOGDIR"
 NEWCJOB="30 0 $1 $2 *   $USER    $INSTEXE $LOGDIR"
 $SUDO crontab -u $USER -l | grep -v '/noip-renew*'  | $SUDO crontab -u $USER -


### PR DESCRIPTION
This is a fix for an error I encountered.
The file name is noip-renew-pi.sh but your cronjob is creating a call to noip-renew-pi (missing the .sh)

$ /usr/local/bin/noip-renew-pi
$ bash: /usr/local/bin/noip-renew-pi: No such file or directory