### PR TITLE
Make cron times consistent in setup and skd

### DIFF
--- a/noip-renew-skd.sh
+++ b/noip-renew-skd.sh
@@ -4,8 +4,8 @@ SUDO=sudo
 LOGDIR=/var/log/noip-renew/$USER
 INSTDIR=/usr/local/bin
 INSTEXE=$INSTDIR/noip-renew-$USER
-CRONJOB="30 0 * * *   $USER    $INSTEXE $LOGDIR"
-NEWCJOB="30 0 $1 $2 *   $USER    $INSTEXE $LOGDIR"
+CRONJOB="0 1 * * *   $USER    ${INSTEXE}.sh $LOGDIR"
+NEWCJOB="0 1 $1 $2 *   $USER    ${INSTEXE}.sh $LOGDIR"
 $SUDO crontab -u $USER -l | grep -v '/noip-renew*'  | $SUDO crontab -u $USER -
 if [[ $3 = "True" ]]; then
     ($SUDO crontab -u $USER -l; echo "$NEWCJOB") | $SUDO crontab -u $USER -


### PR DESCRIPTION
Default cron is set as 0 1 in setup file and 30 0 in skd file

Change cron in skd file to 0 1 to be consistent with setup.sh
https://github.com/loblab/noip-renew/blob/master/setup.sh#L23

Also incorporates fix from https://github.com/loblab/noip-renew/pull/77