### PR TITLE
fix for changed expiration label

### DIFF
--- a/noip-renew.py
+++ b/noip-renew.py
@@ -135,14 +135,13 @@ class Robot:
     @staticmethod
     def get_host_expiration_days(host, iteration):
         try:
-            host_remaining_days = host.find_element_by_xpath(".//a[contains(@class,'no-link-style')]").get_attribute("data-original-title")
+            host_remaining_days = host.find_element_by_xpath(".//a[contains(@class,'no-link-style')]")
         except:
-            host_remaining_days = "Expires in 0 days"
-            pass
-        regex_match = re.search("\\d+", host_remaining_days)
-        if regex_match is None:
-            host_remaining_days = host.find_element_by_xpath(".//a[contains(@class,'no-link-style')]").text
-        regex_match = re.search("\\d+", host_remaining_days)
+            return 0
+        if host_remaining_days.get_attribute("data-original-title") is not None:
+            regex_match = re.search("\\d+", host_remaining_days.get_attribute("data-original-title"))
+        else:
+            regex_match = re.search("\\d+", host_remaining_days.text)
         if regex_match is None:
             raise Exception("Expiration days label does not match the expected pattern in iteration: {iteration}")
         expiration_days = int(regex_match.group(0))

--- a/noip-renew.py
+++ b/noip-renew.py
@@ -135,13 +135,13 @@ class Robot:
     @staticmethod
     def get_host_expiration_days(host, iteration):
         try:
-            host_remaining_days = host.find_element_by_xpath(".//a[@class='no-link-style']").get_attribute("title")
+            host_remaining_days = host.find_element_by_xpath(".//a[contains(@class,'no-link-style')]").get_attribute("data-original-title")
         except:
             host_remaining_days = "Expires in 0 days"
             pass
         regex_match = re.search("\\d+", host_remaining_days)
         if regex_match is None:
-            host_remaining_days = host.find_element_by_xpath(".//a[@class='no-link-style']").text
+            host_remaining_days = host.find_element_by_xpath(".//a[contains(@class,'no-link-style')]").text
         regex_match = re.search("\\d+", host_remaining_days)
         if regex_match is None:
             raise Exception("Expiration days label does not match the expected pattern in iteration: {iteration}")

--- a/noip-renew.py
+++ b/noip-renew.py
@@ -135,7 +135,7 @@ class Robot:
     @staticmethod
     def get_host_expiration_days(host, iteration):
         try:
-            host_remaining_days = host.find_element_by_xpath(".//a[@class='no-link-style']").text
+            host_remaining_days = host.find_element_by_xpath(".//a[@class='no-link-style']").get_attribute("title")
         except:
             host_remaining_days = "Expires in 0 days"
             pass

--- a/noip-renew.py
+++ b/noip-renew.py
@@ -95,7 +95,7 @@ class Robot:
             expiration_days = self.get_host_expiration_days(host, iteration)
             next_renewal.append(expiration_days)
             self.logger.log(f"{host_name} expires in {str(expiration_days)} days")
-            if expiration_days < 7:
+            if expiration_days <= 7:
                 self.update_host(host_button, host_name)
                 count += 1
             iteration += 1
@@ -139,6 +139,9 @@ class Robot:
         except:
             host_remaining_days = "Expires in 0 days"
             pass
+        regex_match = re.search("\\d+", host_remaining_days)
+        if regex_match is None:
+            host_remaining_days = host.find_element_by_xpath(".//a[@class='no-link-style']").text
         regex_match = re.search("\\d+", host_remaining_days)
         if regex_match is None:
             raise Exception("Expiration days label does not match the expected pattern in iteration: {iteration}")


### PR DESCRIPTION
the website now shows "Active" in the text of the button to renew the hostname, the days to expiration are now part of the "title" attribute (showing up only when hovering the mouse).